### PR TITLE
Modify idsvr changes to maintain backwards compatibility

### DIFF
--- a/charts/idsvr/Chart.yaml
+++ b/charts/idsvr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: idsvr
-version: 0.0.3
+version: 0.0.4
 appVersion: 6.7.3
 description: A Helm chart for Curity Identity Server
 keywords:

--- a/charts/idsvr/templates/deployment-admin.yaml
+++ b/charts/idsvr/templates/deployment-admin.yaml
@@ -50,9 +50,16 @@ spec:
             - name: SECRET_NAME
               value: {{ include "curity.fullname" . }}-config-backup
           {{- end }}
-          {{- if .Values.curity.admin.extraEnv }}
-{{ toYaml .Values.curity.admin.extraEnv | indent 12 }}
-          {{- end }}
+          {{- range $env := .Values.curity.admin.extraEnv }}
+            - name: {{ $env.name }}
+            {{- if $env.value }}
+              value: {{ $env.value | quote }}
+            {{- end }}
+            {{- if $env.valueFrom }}
+              valueFrom: 
+{{ $env.valueFrom | toYaml | trim | indent 16 }}
+            {{- end }}
+          {{- end}}
           {{- if ( or .Values.curity.config.environmentVariableSecret .Values.curity.config.environmentVariableConfigMap ) }}
           envFrom:
           {{- if .Values.curity.config.environmentVariableConfigMap }}

--- a/charts/idsvr/templates/deployment-runtime.yaml
+++ b/charts/idsvr/templates/deployment-runtime.yaml
@@ -36,8 +36,15 @@ spec:
               value: {{ .Values.curity.healthCheckPort | quote }}
             - name: LOGGING_LEVEL
               value: {{ .Values.curity.runtime.logging.level }}
-            {{- if .Values.curity.runtime.extraEnv }}
-{{ toYaml .Values.curity.runtime.extraEnv | indent 12 }}
+            {{- range $env := .Values.curity.admin.extraEnv }}
+            - name: {{ $env.name }}
+              {{- if $env.value }}
+              value: {{ $env.value | quote }}
+              {{- end }}
+              {{- if $env.valueFrom }}
+              valueFrom: 
+{{ $env.valueFrom | toYaml | trim | indent 16 }}
+              {{- end }}
             {{- end }}
           {{- if ( or .Values.curity.config.environmentVariableSecret .Values.curity.config.environmentVariableConfigMap ) }}
           envFrom:


### PR DESCRIPTION
Keep the value quote functionality and only expand the `valueFrom` to maintain backwards compatibility for other users of this chart﻿
